### PR TITLE
在使用多个cache的时候 此处$_driver会造成污染

### DIFF
--- a/class/Gini/Cache.php
+++ b/class/Gini/Cache.php
@@ -43,10 +43,11 @@ class Cache
     // \Gini\Cache::of('default')->set('a', 'b');
     public static function of($name)
     {
+        $conf = (array) (\Gini\Config::get("cache.$name") ?: \Gini\Config::get("cache.default"));
+        $_driver = $conf['driver'];
         if (!isset(self::$_CACHE[$_driver])) {
-            $conf = (array) (\Gini\Config::get("cache.$name") ?: \Gini\Config::get("cache.default"));
             self::$_CACHE[$_driver] = \Gini\IoC::construct('\Gini\Cache', $name,
-                $conf['driver'] ?: 'none', (array) $conf['options']);
+                    $conf['driver'] ?: 'none', (array) $conf['options']);
         }
 
         return self::$_CACHE[$_driver];


### PR DESCRIPTION
造成后续的cache会使用default 或者首个cache的配置